### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:latest
+RUN apt-get update && \
+    apt-get install -y python \
+                       libpq-dev \
+                       libjpeg-dev \
+                       libfreetype6-dev \
+                       python-dev \
+                       python-pip \
+    && apt-get clean \
+    && apt-get autoclean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ADD . /app
+RUN cd /app; pip install -r requirements.txt
+WORKDIR /app
+
+ENV LEANCLOUD_APP_ID test_app_id
+ENV LEANCLOUD_APP_KEY test_app_key
+
+RUN python db_store.py
+CMD ["python", "/app/wechat_group_bot.py"]


### PR DESCRIPTION
后期可使用alpine作为基础镜像，进一步缩小镜像体积。

以后并可将是否网络存储记录作为环境变量引入。

也可以使用http服务器将登录二维码进行展示。